### PR TITLE
implement series, actors and images endpoints

### DIFF
--- a/client.go
+++ b/client.go
@@ -273,3 +273,90 @@ func (client *Client) initialize() error {
 
 	return nil
 }
+
+// GetSeriesActors gets all available actors for a given show id
+func (client *Client) GetSeriesActors(request SeriesRequest) ([]SeriesActorResponse, error) {
+	//	Create our return value
+	retval := []SeriesActorResponse{}
+
+	//	Initialize our client
+	if err := client.initialize(); err != nil {
+		return retval, err
+	}
+
+	//	Set the API url
+	apiURL := client.ServiceURL + fmt.Sprintf("/series/%v/actors", request.SeriesID)
+
+	//	Construct our query
+	u, err := url.Parse(apiURL)
+	if err != nil {
+		return retval, err
+	}
+
+	q := u.Query()
+
+	u.RawQuery = q.Encode()
+
+	//	Prep the response object
+	object := SeriesActorResponses{}
+
+	//	Make the API call
+	if err := client.makeAPIcall(u, &object); err != nil {
+		return retval, err
+	}
+	retval = object.Data
+
+	//	Return our response
+	return retval, nil
+}
+
+// GetSeriesImages gets images for a given show id and image type, if no KeyType is given it defaults to poster
+func (client *Client) GetSeriesImages(request SeriesImageQueryRequest) ([]SeriesImageQueryResponse, error) {
+	//	Create our return value
+	retval := []SeriesImageQueryResponse{}
+
+	//	Initialize our client
+	if err := client.initialize(); err != nil {
+		return retval, err
+	}
+
+	//	Set the API url
+	apiURL := client.ServiceURL + fmt.Sprintf("/series/%v/images/query", request.SeriesID)
+
+	//	Construct our query
+	u, err := url.Parse(apiURL)
+	if err != nil {
+		return retval, err
+	}
+
+	q := u.Query()
+
+	if request.KeyType != "" {
+		q.Set("keyType", request.KeyType)
+	} else {
+		// make sure we have a keyType set!
+		q.Set("keyType", "poster")
+	}
+
+	if request.Resulution != "" {
+		q.Set("resolution", request.Resulution)
+	}
+
+	if request.SubKey != "" {
+		q.Set("subKey", request.SubKey)
+	}
+
+	u.RawQuery = q.Encode()
+
+	//	Prep the response object
+	object := SeriesImageQueryResponses{}
+
+	//	Make the API call
+	if err := client.makeAPIcall(u, &object); err != nil {
+		return retval, err
+	}
+	retval = object.Data
+
+	//	Return our response
+	return retval, nil
+}

--- a/client.go
+++ b/client.go
@@ -169,6 +169,43 @@ func (client *Client) GetUpdated(request UpdatedRequest) ([]UpdatedResponse, err
 	return retval, nil
 }
 
+// GetSeries get's information about a given TV series
+func (client *Client) GetSeries(request SeriesRequest) (SeriesResponse, error) {
+
+	//	Create our return value
+	retval := SeriesResponse{}
+
+	//	Initialize our client
+	if err := client.initialize(); err != nil {
+		return retval, err
+	}
+
+	//	Set the API url
+	apiURL := client.ServiceURL + fmt.Sprintf("/series/%v", request.SeriesID)
+
+	//	Construct our query
+	u, err := url.Parse(apiURL)
+	if err != nil {
+		return retval, err
+	}
+
+	q := u.Query()
+
+	u.RawQuery = q.Encode()
+
+	//	Prep the response object
+	object := SeriesResponses{}
+
+	//	Make the API call
+	if err := client.makeAPIcall(u, &object); err != nil {
+		return retval, err
+	}
+	retval = object.Data
+
+	//	Return our response
+	return retval, nil
+}
+
 // EpisodesForSeries searches for episodes in a given TV series
 func (client *Client) EpisodesForSeries(request EpisodeRequest) ([]EpisodeResponse, error) {
 

--- a/series.go
+++ b/series.go
@@ -46,3 +46,51 @@ type EpisodeResponses struct {
 	Links EpisodeResponseLinks `json:"links"`
 	Data  []EpisodeResponse    `json:"data"`
 }
+
+// SeriesRequest is used to request additional series information
+type SeriesRequest struct {
+	SeriesID int `json:"id"`
+}
+
+// SeriesActorResponse contains information about a single actor
+type SeriesActorResponse struct {
+	ID          int    `json:"id"`
+	Image       string `json:"image"`
+	ImageAdded  string `json:"imageAdded"`
+	ImageAuthor int    `json:"imageAuthor"`
+	LastUpdated string `json:"lastUpdated"`
+	Name        string `json:"name"`
+	Role        string `json:"role"`
+	SeriesID    int    `json:"seriesId"`
+	SortOrder   int    `json:"sortOrder"`
+}
+
+// SeriesActorResponses is the response of the api when asking for authors
+type SeriesActorResponses struct {
+	Data []SeriesActorResponse `json:"data"`
+}
+
+// SeriesImageQueryRequest used to query images for a given series and type
+type SeriesImageQueryRequest struct {
+	SeriesID   int    `json:"id"`
+	KeyType    string `json:"keyType"`
+	Resulution string `json:"resulution"`
+	SubKey     string `json:"subKey"`
+}
+
+// SeriesImageQueryResponse one single image response
+type SeriesImageQueryResponse struct {
+	FileName    string             `json:"fileName"`
+	ID          int                `json:"id"`
+	KeyType     string             `json:"keyType"`
+	LanguageID  int                `json:"languageId"`
+	RatingsInfo map[string]float64 `json:"ratingsInfo"`
+	Resolution  string             `json:"resulution"`
+	SubKey      string             `json:"subKey"`
+	Thumbnail   string             `json:"thumbnail"`
+}
+
+// SeriesImageQueryResponses is the response of the api when asking for images
+type SeriesImageQueryResponses struct {
+	Data []SeriesImageQueryResponse `json:"data"`
+}

--- a/series.go
+++ b/series.go
@@ -1,5 +1,40 @@
 package tvdb
 
+// SeriesRequest is used to request additional series information
+type SeriesRequest struct {
+	SeriesID int `json:"id"`
+}
+
+// SeriesResponse represents a reponse for series information from the TVDB service
+type SeriesResponse struct {
+	Added           string   `json:"added"`
+	AirsDayOfWeek   string   `json:"airsDayOfWeek"`
+	AirsTime        string   `json:"airsTime"`
+	Aliases         []string `json:"aliases"`
+	Banner          string   `json:"banner"`
+	FirstAired      string   `json:"firstAired"`
+	Genre           []string `json:"genre"`
+	ID              int      `json:"id"`
+	ImdbID          string   `json:"imdbId"`
+	LastUpdated     int      `json:"lastUpdated"`
+	Network         string   `json:"network"`
+	NetworkID       string   `json:"networkId"`
+	Overview        string   `json:"overview"`
+	Rating          string   `json:"rating"`
+	Runtime         string   `json:"runtime"`
+	SeriesID        string   `json:"seriesId"`
+	SeriesName      string   `json:"seriesName"`
+	SiteRating      float64  `json:"siteRating"`
+	SiteRatingCount int      `json:"siteRatingCount"`
+	Status          string   `json:"status"`
+	Zap2itID        string   `json:"zap2itId"`
+}
+
+// SeriesResponses represents the list of responses to get series information
+type SeriesResponses struct {
+	Data SeriesResponse `json:"data"`
+}
+
 // EpisodeRequest represents a request to get episode information
 type EpisodeRequest struct {
 	SeriesID int
@@ -45,11 +80,6 @@ type EpisodeResponseLinks struct {
 type EpisodeResponses struct {
 	Links EpisodeResponseLinks `json:"links"`
 	Data  []EpisodeResponse    `json:"data"`
-}
-
-// SeriesRequest is used to request additional series information
-type SeriesRequest struct {
-	SeriesID int `json:"id"`
 }
 
 // SeriesActorResponse contains information about a single actor


### PR DESCRIPTION
Just a thought: the current naming of the Structs is not really clear... might change them:

SeriesResponse => Series
EpisodeResponse => Episode
etc.

i found that the model names provided by https://api.thetvdb.com/swagger#!/Series/get_series_id make a lot of sense when it comes to Naming